### PR TITLE
Make GitHub detect {cmd,con,lib,lock,macro}-* as MUF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 -text
+cmd-* linguist-language=MUF
+con-* linguist-language=MUF
+lib-* linguist-language=MUF
+lock-* linguist-language=MUF
+macro-* linguist-language=MUF


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `cmd-*`, `con-*`, `lib-*`, `lock-*`, and `macro-*` files as MUF.

Thanks!